### PR TITLE
Fix crash on inaccessible directory

### DIFF
--- a/src/fileinput.cpp
+++ b/src/fileinput.cpp
@@ -46,7 +46,9 @@ void FileInput::auto_complete() {
 
   count = 0;
   if (directory_exists(q_path)) {
-    for (const auto &entry : FILESYSTEM::directory_iterator(q_path->toStdString())) {
+    for (auto it = FILESYSTEM::recursive_directory_iterator(q_path->toStdString(), FILESYSTEM::directory_options::skip_permission_denied); it != FILESYSTEM::recursive_directory_iterator(); ++it) {
+      if (it.depth() > 0) continue;
+      const auto entry = *it;
       string entry_str = entry.path();
 
       size_t e_slash = entry_str.rfind("/") + 1;


### PR DESCRIPTION
qmarkdown crashes if a directory with inaccessible permissions (e.g. owner root, mode 0700) is encountered while scanning the
workspace. The crash is caused by an exception which is thrown by the `fs::directory_iterator`.

This is similar to the fix I have done [here](https://github.com/actboy168/bee.lua/pull/20), but unfortunately a little less pretty in the case of `auto_complete` where we don't need any recursion: the legacy API `std::experimental::filesystem::directory_iterator::directory_iterator` does not provide the option to set `directory_options` in the second argument, so I had to switch to the recursive version and bail out on depth > 0. In the case of `resgen.cpp` it removes the need for manual recursion.