### PR TITLE
Fix relative Image sources

### DIFF
--- a/src/document.cpp
+++ b/src/document.cpp
@@ -21,11 +21,8 @@ QString Document::text() const {
 }
 
 QString Document::imageToBase64(const QString &imagePath) {
-    QString absolutePath = imagePath;
-    if (imagePath.startsWith(".") || imagePath.startsWith("/")) {
-        QFileInfo currentDir(".");
-        absolutePath = currentDir.absolutePath() + "/" + imagePath;
-    }
+    QFileInfo f(imagePath);
+    QString absolutePath = f.absoluteFilePath();
 
     QFile imageFile(absolutePath);
     QFileInfo fileInfo(absolutePath);

--- a/src/resources/index-dark.html
+++ b/src/resources/index-dark.html
@@ -23,7 +23,7 @@
             const images = document.getElementsByTagName("img");
             for (const image of images) {
                 const src = image.getAttribute("src");
-                if (src.startsWith(".") || src.startsWith("/")) {
+                if (!src.startsWith("http://") && !src.startsWith("https://")) {
                     image.src = await obj.imageToBase64(src);
                 }
             }

--- a/src/resources/index-light.html
+++ b/src/resources/index-light.html
@@ -23,7 +23,7 @@
             const images = document.getElementsByTagName("img");
             for (const image of images) {
                 const src = image.getAttribute("src");
-                if (src.startsWith(".") || src.startsWith("/")) {
+                if (!src.startsWith("http://") && !src.startsWith("https://")) {
                     image.src = await obj.imageToBase64(src);
                 }
             }


### PR DESCRIPTION
While `./img.src` and `/img.src` are accounted for, `../img.src` and `img.src` are not recognized as
local image sources and hence displayed as broken
image links.

To sidestep this problem, consider any image source not starting with http{,s}:// a local image source.